### PR TITLE
🐋Dockerfile, docker-compose and prebuilt Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM debian:buster
+
+WORKDIR /app
+
+RUN apt-get update -y
+
+RUN apt-get install -y unzip wget git default-jdk chromium=90.0.4430.93-1~deb10u1
+
+RUN wget https://chromedriver.storage.googleapis.com/90.0.4430.24/chromedriver_linux64.zip
+
+RUN unzip chromedriver_linux64.zip
+
+RUN rm chromedriver_linux64.zip
+
+RUN wget https://services.gradle.org/distributions/gradle-7.0-bin.zip  -P /tmp/
+
+RUN unzip -d /opt/gradle /tmp/gradle-7.0-bin.zip
+
+RUN rm -rf /tmp/gradle-7.0-bin.zip
+
+RUN git clone https://github.com/TobseF/impf-bot.git
+
+RUN mv impf-bot/* .
+
+RUN rm -rf impf-bot/
+
+RUN /opt/gradle/gradle-7.0/bin/gradle build
+
+RUN useradd -ms /bin/bash impfbot
+
+RUN chown -R impfbot:impfbot /app
+
+USER impfbot
+
+RUN sed -i -e 's/\ \ \ \ val\ chromeDriver\ =\ ChromeDriver()/\ \ \ \ val\ options\ =\ ChromeOptions\(\)\n\ \ \ \ options.addArguments\("--headless"\)\n\ \ \ \ options.addArguments\("--no-sandbox"\);\n\ \ \ \ options.addArguments\("--disable-dev-shm-usage"\);\n\ \ \ \ val\ chromeDriver\ =\ ChromeDriver\(options\)/g' src/main/kotlin/de/tfr/impf/selenium/DriverFactory.kt
+
+RUN sed -i -e 's/import\ mu.KotlinLogging/import\ mu.KotlinLogging\nimport\ org.openqa.selenium.chrome.ChromeOptions/g' src/main/kotlin/de/tfr/impf/selenium/DriverFactory.kt
+
+ENTRYPOINT ["/opt/gradle/gradle-7.0/bin/gradle", "run" ]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ slackBotChannel = #random
 ### Setup Slack
 This step is optional. You can find detailed setup instructions here: [SlackBot Setup](/doc/slack_setup/SLACK_SETUP.md).
 
+### Docker
+To run this tool in Docker, follow this tutorial: [Docker](/doc/docker/DOCKER_SETUP.md).
+
 ### `simplelogger.properties`
 
 To change the Log-Level edit the `defaultLogLevel`:  

--- a/doc/docker/DOCKER_SETUP.md
+++ b/doc/docker/DOCKER_SETUP.md
@@ -9,10 +9,11 @@ If your dont have an existing file, follow the config.properties guide in the ma
 <br>
 Now open the file in your favourite editor and edit the Chromedriver options to match the working ones for the container:
 <br>
-```
-pathDriver = /app
+
+```PathDriver = /app
 nameDriver = webdriver.chrome.driver
-exeDriver = chromedriver```
+exeDriver = chromedriver
+```
 
 <br><br>
 Now your are ready to go on with the quickstart or build the container yourself
@@ -38,6 +39,7 @@ in the root folder of the project.
 <br><br>
 
 Both options deploy a running container with the name impf-bot in the background.
+Congratulations, your container is now up- and running and searching for an appointment
 
 <br><br>
 To get logs from the container:

--- a/doc/docker/DOCKER_SETUP.md
+++ b/doc/docker/DOCKER_SETUP.md
@@ -1,0 +1,60 @@
+# 🐋🛠 Docker
+
+## 1. Prepare config.properties
+
+If you have an already existing config.properties, you can copy it to the root folder of the project for convenience, so you wont have to alter the following commands
+
+If your dont have an existing file, follow the config.properties guide in the main [README.md](https://github.com/TobseF/impf-bot/blob/master/README.md) and copy it to the projects root folder.
+
+<br>
+Now open the file in your favourite editor and edit the Chromedriver options to match the working ones for the container:
+<br>
+```
+pathDriver = /app
+nameDriver = webdriver.chrome.driver
+exeDriver = chromedriver```
+
+<br><br>
+Now your are ready to go on with the quickstart or build the container yourself
+<br><br>
+
+## 2.1 Quickstart
+
+To simply run the container pre-built, either execute
+
+```docker run --name impf-bot -d -v $PWD/config.properties:/app/src/main/resources/config.properties pfuenzle/impf-bot```
+
+and replace ```$PWD/config.properties``` with the path and filename to your properties file (if config.properties is not in your current path)
+<br><br>
+
+OR 
+<br><br>
+
+replace ```./config.properties``` in docker-compose.yml with the path and filename to your properties file (if config.properties is not in the same folder as docker-compose.yml) and then execute 
+
+```docker-compose up -d```
+
+in the root folder of the project.
+<br><br>
+
+Both options deploy a running container with the name impf-bot in the background.
+
+<br><br>
+To get logs from the container:
+
+```docker logs impf-bot```
+
+To stop the container:
+
+```docker stop impf-bot && docker rm impf-bot```
+<br><br>
+
+## 2.2 Build container yourself
+
+To build the container yourself, go to the projects root folder and execute
+
+```docker build . -t impf-bot```
+
+After successfully building the container, follow the Quickstart guide, but replace 
+
+```pfuenzle/impf-bot``` with ```impf-bot```, to use your local build instead of the prebuilt version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+---
+version: "3"
+services:
+    impf-bot:
+        image: pfuenzle/impf-bot
+        container_name: impf-bot
+        volumes:
+            - ./config.properties:/app/src/main/resources/config.properties
+        restart: unless-stopped
+    


### PR DESCRIPTION
This adds a Dockerfile for impf-bot with a mountable config file, a docker-compose.yml for easy deployment and documentation for either running the prebuilt version or building and running your own built container.

One thing to note is that I had to patch Driverfactory.kt to enable the headless mode and disable the sandbox in chrome to make it work in docker.

Im pretty confident that this patch is compatible with future modified versions Driverfactory.kt without changing the Dockerfile, but if it is not for any reason, I will fix it as soon as possible