### PR TITLE
VNC/WebGUI support for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apt-get update -y
 
-RUN apt-get install -y unzip wget git default-jdk chromium=90.0.4430.93-1~deb10u1
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y unzip wget git default-jdk chromium=90.0.4430.93-1~deb10u1 xorg tightvncserver autocutsel lxde-core novnc python-websockify 
 
 RUN wget https://chromedriver.storage.googleapis.com/90.0.4430.24/chromedriver_linux64.zip
 
@@ -24,16 +24,37 @@ RUN mv impf-bot/* .
 
 RUN rm -rf impf-bot/
 
+RUN sed -i -e 's/\ \ \ \ val\ chromeDriver\ =\ ChromeDriver(chromeOptions)/\ \ \ \ System.setProperty("webdriver.chrome.whitelistedIps", "");\n\ \ \ \ chromeOptions.addArguments\("--no-sandbox"\);\n\ \ \ \ chromeOptions.addArguments\("--disable-dev-shm-usage"\);\n\ \ \ \ val\ chromeDriver\ =\ ChromeDriver\(chromeOptions\)/g' src/main/kotlin/de/tfr/impf/selenium/DriverFactory.kt
+
+RUN cat src/main/kotlin/de/tfr/impf/selenium/DriverFactory.kt
+
 RUN /opt/gradle/gradle-7.0/bin/gradle build
 
-RUN useradd -ms /bin/bash impfbot
+RUN cat src/main/kotlin/de/tfr/impf/selenium/DriverFactory.kt
 
-RUN chown -R impfbot:impfbot /app
+RUN echo "# XScreenSaver Preferences File\nmode:		off\nselected:	-1" > /root/.xscreensaver
 
-USER impfbot
+RUN cat /root/.xscreensaver
 
-RUN sed -i -e 's/\ \ \ \ val\ chromeDriver\ =\ ChromeDriver()/\ \ \ \ val\ options\ =\ ChromeOptions\(\)\n\ \ \ \ options.addArguments\("--headless"\)\n\ \ \ \ options.addArguments\("--no-sandbox"\);\n\ \ \ \ options.addArguments\("--disable-dev-shm-usage"\);\n\ \ \ \ val\ chromeDriver\ =\ ChromeDriver\(options\)/g' src/main/kotlin/de/tfr/impf/selenium/DriverFactory.kt
+RUN mkdir /root/.vnc/
 
-RUN sed -i -e 's/import\ mu.KotlinLogging/import\ mu.KotlinLogging\nimport\ org.openqa.selenium.chrome.ChromeOptions/g' src/main/kotlin/de/tfr/impf/selenium/DriverFactory.kt
+RUN echo "#!/bin/sh\n/usr/bin/autocutsel -s CLIPBOARD -fork\nxrdb $HOME/.Xresources\nxsetroot -solid grey\n#x-terminal-emulator -geometry 80x24+10+10 -ls -title \"$VNCDESKTOP Desktop\" &\n#x-window-manager &\n# Fix to make GNOME work\nexport XKL_XMODMAP_DISABLE=1\n/etc/X11/Xsession &\nx-terminal-emulator -e \"/opt/gradle/gradle-7.0/bin/gradle run 2>&1 | tee /app/impflog\"" > /root/.vnc/xstartup
+RUN chmod +x /root/.vnc/xstartup
 
-ENTRYPOINT ["/opt/gradle/gradle-7.0/bin/gradle", "run" ]
+RUN cat /root/.vnc/xstartup
+
+RUN mv /usr/share/novnc/vnc.html /usr/share/novnc/index.html
+
+RUN echo "#!/bin/bash\necho -n \${VNC_PASSWORD:-impf-bot} | vncpasswd -f > /root/.vnc/passwd\nchmod 400 ~/.vnc/passwd\n\nexport USER=root\nvncserver :1 -geometry 1920x1080 -depth 24 && websockify -D --web=/usr/share/novnc/ 6901 localhost:5901\ntail -f /app/impflog" > /root/vnc-startup.sh
+RUN chmod +x /root/vnc-startup.sh
+
+RUN cat /root/vnc-startup.sh
+
+RUN chmod go-rwx /root/.vnc
+
+EXPOSE 5901
+EXPOSE 6901
+
+CMD ["/root/vnc-startup.sh"]
+
+#ENTRYPOINT ["/opt/gradle/gradle-7.0/bin/gradle", "run" ]

--- a/doc/docker/DOCKER_SETUP.md
+++ b/doc/docker/DOCKER_SETUP.md
@@ -35,11 +35,21 @@ replace ```./config.properties``` in docker-compose.yml with the path and filena
 
 ```docker-compose up -d```
 
-in the root folder of the project.
-<br><br>
+in the root folder of the project. 
+
 
 Both options deploy a running container with the name impf-bot in the background.
-Congratulations, your container is now up- and running and searching for an appointment
+Congratulations, your container is now up- and running and searching for an appointment  
+
+<br>
+### UI
+
+The container has two open ports: 5901 (vnc) and 6901 (web).
+
+If an appointment has been found or you want to check in on the process, 
+either connect to ```127.0.0.1:5901``` with a VNC Client of your choice
+or
+open ```127.0.0.1:6901``` in any available webbrowser
 
 <br><br>
 To get logs from the container:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
         image: pfuenzle/impf-bot
         container_name: impf-bot
         volumes:
-            - ./config.properties:/app/src/main/resources/config.properties
+            - ../config.properties:/app/src/main/resources/config.properties
+        ports:
+            - 5901:5901
+            - 6901:6901
         restart: unless-stopped
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         image: pfuenzle/impf-bot
         container_name: impf-bot
         volumes:
-            - ../config.properties:/app/src/main/resources/config.properties
+            - ./config.properties:/app/src/main/resources/config.properties
         ports:
             - 5901:5901
             - 6901:6901


### PR DESCRIPTION
With the updated docker image, it is possible to interact with the browser window via VNC or any webbrowser.
This also very likely fixes https://github.com/TobseF/impf-bot/issues/18