### PR TITLE
feat: provide distinct server code with placement code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Edit these settings before the first run. A missing boolean property will be tre
 
 ```properties
 mainPageUrl = https://www.impfterminservice.de/impftermine
-# Comma separated list of locations. Optional, if you already have a placement code just add it in square brackets after the place.
-locations = 69124 Heidelberg[XXXX-XXXX-XXXX],76137 Karlsruhe
+# Comma separated list of locations. Optional, if you already have a placement code just add it in square brackets after the place. Since placement codes are not related to locations but to servers you can furthermore optionally specify the related server code next to the placement code in parentheses. The server code can be found in the URL e.g. "001-iz.impfterminservice.de" -> server code == "001".
+locations = 69124 Heidelberg[XXXX-XXXX-XXXX](XXX),76137 Karlsruhe
 
 # Your age. Used in age verification field.
 personAge = 42

--- a/src/main/kotlin/de/tfr/impf/ReportJob.kt
+++ b/src/main/kotlin/de/tfr/impf/ReportJob.kt
@@ -76,8 +76,12 @@ class ReportJob {
         locationPage: LocationPage,
         location: Config.Location
     ) {
-        locationPage.confirmClaim()
         val code = location.placementCode
+        val serverCode = location.serverCode
+        if (serverCode != null) {
+            locationPage.switchToDifferentServer(serverCode)
+        }
+        locationPage.confirmClaim()
         if (code != null) {
             locationPage.enterCodeSegment0(code)
             locationPage.searchForFreeDate()

--- a/src/main/kotlin/de/tfr/impf/config/Config.kt
+++ b/src/main/kotlin/de/tfr/impf/config/Config.kt
@@ -90,12 +90,14 @@ object Config : KProperties() {
      */
     private fun parseLocation(locationStatement: String): Location {
         val placementCode = locationStatement.substringAfter("[", "").substringBefore("]", "").ifEmpty { null }
+        val serverCode = locationStatement.substringAfter("(","").substringBefore(")", "").ifEmpty { null }
         val name = locationStatement.substringBefore("[")
-        return Location(name, placementCode)
+        return Location(name, placementCode, serverCode)
     }
 
-    class Location(val name: String, val placementCode: String?) {
+    class Location(val name: String, val placementCode: String?, val serverCode: String?) {
         fun hasCode() = placementCode != null
+        fun hasServerCode() = serverCode != null
 
         private fun getCodeSegment(index: Int): String = (placementCode?.split("-")?.get(index)).orEmpty()
         fun getCodeSegment0(): String = getCodeSegment(0)

--- a/src/main/kotlin/de/tfr/impf/page/LocationPage.kt
+++ b/src/main/kotlin/de/tfr/impf/page/LocationPage.kt
@@ -1,9 +1,12 @@
 package de.tfr.impf.page
 
+import mu.KotlinLogging
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 
 class LocationPage(driver: WebDriver) : AbstractPage(driver) {
+
+    val log = KotlinLogging.logger("LocationPage")
 
     fun title(): WebElement? = findAnyBy("//h1")
 
@@ -72,5 +75,18 @@ class LocationPage(driver: WebDriver) : AbstractPage(driver) {
 
     fun hasVacError(): Boolean =
         findAll("//span[contains(@class, 'text-pre-wrap') and contains(text(), 'Fehler')]").isNotEmpty()
+
+    fun switchToDifferentServer(serverCode: String) {
+        if (!driver.currentUrl.contains("$serverCode-iz")) {
+            val url = driver.currentUrl
+            val newUrl = if (url.startsWith("https://")) {
+                url.replaceRange(8, 11, serverCode)
+            } else {
+                url.replaceRange(0, 2, serverCode)
+            }
+            log.debug("Redirect to distinct IZ Server. From: $url to: $newUrl")
+            driver.get(newUrl)
+        }
+    }
 
 }

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,6 +1,6 @@
 mainPageUrl = https://www.impfterminservice.de/impftermine
-# Comma separated list of locations. Optional, if you already have a placement code just add it in square brackets after the place.
-locations = 69124 Heidelberg[XXXX-XXXX-XXXX],76137 Karlsruhe
+# Comma separated list of locations. Optional, if you already have a placement code just add it in square brackets after the place. Furthermore you can optionally specify the related server code next to the placement code in parentheses (can be found in the URL e.g. "001-iz.impfterminservice.de -> server code == 001).
+locations = 69124 Heidelberg[XXXX-XXXX-XXXX](XXX),76137 Karlsruhe
 
 # Your age. Used in age verification field.
 personAge = 42


### PR DESCRIPTION
Since placement codes do actually relate to the servers and not to locations (#5) I extended the current config such that you can also provide the server code from which the placement code has been issued. This can be done by providing the related server code in parentheses like the following:

```
locations = 69123 Heidelberg[XXXX-XXXX-XXXX](XXX)
```

The big advantage of this is, that you can now use your placement code in every location you want to use them for. So lets assume you have a code generated from server `001-iz.impfterminservice.de` and location `69124 Heidelberg` but you want to use this code for the location `69123 Heidelberg` which actually works with server `002-iz.impfterminservice.de`. In order to do that you simply need to provide the code `(001)` in parentheses behind the placement code: `69123 Heidelberg[XXXX-XXXX-XXXX](001)`. With this config the impf-bot will directly go to the correct server and enter the corresponding placement code accordingly.

Regards Timo