### PR TITLE
fix false positives for available slots

### DIFF
--- a/src/main/kotlin/de/tfr/impf/page/BookingPage.kt
+++ b/src/main/kotlin/de/tfr/impf/page/BookingPage.kt
@@ -13,7 +13,7 @@ class BookingPage(driver: WebDriver) : AbstractPage(driver) {
     override fun isDisplayed() = title()?.text == "Onlinebuchung für Ihre Corona-Schutzimpfung"
 
     fun isDisplayingVaccinationDates(): Boolean {
-        return findAll("//div[contains(@class, 'its-search-step-title') and contains(text(), 'Impftermine')]").isNotEmpty()
+        return findAll("//*[contains(text(), '1. Impftermin')]").isNotEmpty()
     }
 
 }


### PR DESCRIPTION
sometimes the check for available dates will fail, because requests are rather slow (30-60s) after the waiting queue disappears. This will fix false positives

```
<div _ngcontent-nfa-c125="" class="d-none d-lg-flex its-slot-pair-search-title"><div _ngcontent-nfa-c125="" class="d-flex its-slot-pair-search-slot-wrapper"><span _ngcontent-nfa-c125="" class="flex-fill"><strong _ngcontent-nfa-c125="">1. Impftermin</strong></span><span _ngcontent-nfa-c125="" class="its-slot-pair-search-slot-sep"></span><span _ngcontent-nfa-c125="" class="flex-fill"><strong _ngcontent-nfa-c125="">2. Impftermin</strong></span></div><div _ngcontent-nfa-c125="" class="its-slot-pair-search-radio-wrapper"></div></div>
```