### PR TITLE
Made the state configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Edit these settings before the first run. A missing boolean property will be tre
 
 ```properties
 mainPageUrl = https://www.impfterminservice.de/impftermine
+# Name of the state from the select list
+state = Baden-Württemberg
 # Comma separated list of locations. Optional, if you already have a placement code just add it in square brackets after the place. Since placement codes are not related to locations but to servers you can furthermore optionally specify the related server code next to the placement code in parentheses. The server code can be found in the URL e.g. "001-iz.impfterminservice.de" -> server code == "001".
 locations = 69124 Heidelberg[XXXX-XXXX-XXXX](XXX),76137 Karlsruhe
 

--- a/src/main/kotlin/de/tfr/impf/ReportJob.kt
+++ b/src/main/kotlin/de/tfr/impf/ReportJob.kt
@@ -204,7 +204,7 @@ class ReportJob {
         mainPage.open()
         log.debug { "Choose State: " + mainPage.chooseState()?.text }
         mainPage.chooseState()?.click()
-        mainPage.chooseStateItemBW()
+        mainPage.chooseStateItem(Config.state)
         return mainPage
     }
 }

--- a/src/main/kotlin/de/tfr/impf/config/Config.kt
+++ b/src/main/kotlin/de/tfr/impf/config/Config.kt
@@ -9,6 +9,7 @@ object Config : KProperties() {
     }
 
     val mainPageUrl: String by lazyProperty()
+    val state: String by lazyProperty()
     private val locations: String by lazyProperty()
 
     /**

--- a/src/main/kotlin/de/tfr/impf/page/MainPage.kt
+++ b/src/main/kotlin/de/tfr/impf/page/MainPage.kt
@@ -17,8 +17,8 @@ class MainPage(driver: WebDriver) : AbstractPage(driver) {
 
     fun chooseLocation(): WebElement? = findAll("//span[@role='combobox']").getOrNull(1)
 
-    fun chooseStateItemBW() =
-        findAll("//li[@role='option' and contains(text() , 'Baden-Württemberg')]").firstOrNull()?.click()
+    fun chooseStateItem(stateName: String = "Baden-Württemberg") =
+        findAll("//li[@role='option' and contains(text() , '$stateName')]").firstOrNull()?.click()
 
     fun title(): WebElement = findBy("//h1")
 

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,4 +1,6 @@
 mainPageUrl = https://www.impfterminservice.de/impftermine
+# Name of the state from the select list
+state = Baden-Württemberg
 # Comma separated list of locations. Optional, if you already have a placement code just add it in square brackets after the place. Furthermore you can optionally specify the related server code next to the placement code in parentheses (can be found in the URL e.g. "001-iz.impfterminservice.de -> server code == 001).
 locations = 69124 Heidelberg[XXXX-XXXX-XXXX](XXX),76137 Karlsruhe
 


### PR DESCRIPTION
As I do not live in Baden-Württemberg, I had to change the default value of the state to be selected. As probably others may have the same issue, I made it configurable.
If the config value is not set, it's automatically using "Baden-Württemberg" to stay compatible.