### PR TITLE
Fix "Es ist ein unerwarteter Fehler aufgetreten"

### DIFF
--- a/src/main/kotlin/de/tfr/impf/ReportJob.kt
+++ b/src/main/kotlin/de/tfr/impf/ReportJob.kt
@@ -94,7 +94,9 @@ class ReportJob {
         locationPage.confirmClaim()
         if (code != null) {
             cookieNag.acceptCookies()
+            Thread.sleep(2_000)
             locationPage.enterCodeSegment0(code)
+            Thread.sleep(2_000)
             locationPage.searchForFreeDate()
             locationPage.searchForVaccinateDate()
             val bookingPage = BookingPage(driver)


### PR DESCRIPTION
This fixes the error "Es ist ein unerwarteter Fehler aufgetreten" when checking for an appointment with a Vermittlungscode.

This error appeared consistenly for me, because the bot sends a request immediately when the page is loaded. With this commit, it sleeps 2 seconds each after loading the site and putting in the Vermittlungscode, this permanently fixed the error for me.



![image](https://user-images.githubusercontent.com/11798845/118397148-e924ab00-b652-11eb-9d91-8c517c3f9e93.png)