### PR TITLE
Switch VNC server to fix keyboard issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster
 
 # install apt dependencies
 RUN apt-get update -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y unzip wget git default-jdk chromium=90.0.4430.93-1~deb10u1 xorg tightvncserver autocutsel lxde-core novnc python-websockify 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y unzip wget git default-jdk chromium=90.0.4430.93-1~deb10u1 xorg vnc4server autocutsel lxde-core novnc python-websockify 
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ RUN echo "# XScreenSaver Preferences File\nmode:		off\nselected:  -1" > /root/.x
   chmod +x /root/.vnc/xstartup && \
   cat /root/.vnc/xstartup && \
   mv /usr/share/novnc/vnc.html /usr/share/novnc/index.html && \
-  echo "#!/bin/bash\nxmodmap -e \"keycode 22 = 5 percent\"\nxmodmap -e \"keycode 23 = 6\"\nsetxkbmap -option lv3:rwin_switch\necho -n \${VNC_PASSWORD:-impf-bot} | vncpasswd -f > /root/.vnc/passwd\nchmod 400 ~/.vnc/passwd\n\nexport USER=root\nvncserver :1 -geometry 1920x1080 -depth 24 && websockify -D --web=/usr/share/novnc/ 6901 localhost:5901\ntail -f /app/impflog" > /root/vnc-startup.sh && \
+  echo "#!/bin/bash\nsetxkbmap -option lv3:rwin_switch\necho -n \${VNC_PASSWORD:-impf-bot} | vncpasswd -f > /root/.vnc/passwd\nchmod 400 ~/.vnc/passwd\n\nexport USER=root\nvncserver :1 -geometry 1920x1080 -depth 24 && websockify -D --web=/usr/share/novnc/ 6901 localhost:5901\ntail -f /app/impflog" > /root/vnc-startup.sh && \
   chmod +x /root/vnc-startup.sh && \
   cat /root/vnc-startup.sh && \
   chmod go-rwx /root/.vnc 


### PR DESCRIPTION
As per [known limitations of tightvncserver](https://unix.stackexchange.com/questions/346107/keyboard-mapping-wrong-only-in-specific-applications-under-tightvnc) having no support for `XKEYBOARD` switching to vnc4server to fix the keyboard issues. Primarily for the keys `4`, `5`, `6` - but also numpads and other special keys.

This should also fix https://github.com/TobseF/impf-bot/issues/48 and https://github.com/TobseF/impf-bot/issues/59