### PR TITLE
Accepting cookies before choosing state

### DIFF
--- a/src/main/kotlin/de/tfr/impf/ReportJob.kt
+++ b/src/main/kotlin/de/tfr/impf/ReportJob.kt
@@ -52,8 +52,8 @@ class ReportJob {
 
 
     private fun checkLocation(location: Config.Location) {
-        val mainPage = openMainPage(driver)
         val cookieNag = CookieNagComponent(driver)
+        val mainPage = openMainPage(driver, cookieNag)
         mainPage.isDisplayed()
         cookieNag.acceptCookies()
         mainPage.chooseLocation(location.name)
@@ -208,10 +208,11 @@ class ReportJob {
         }
     }
 
-    private fun openMainPage(driver: WebDriver): MainPage {
+    private fun openMainPage(driver: WebDriver, cookieNag: CookieNagComponent): MainPage {
         val mainPage = MainPage(driver)
         mainPage.open()
         log.debug { "Choose State: " + mainPage.chooseState()?.text }
+        cookieNag.acceptCookies()
         mainPage.chooseState()?.click()
         mainPage.chooseStateItem(Config.state)
         return mainPage


### PR DESCRIPTION
Hi,
I had some issues where the cookies were not accepted before the state selection, blocking it and it therefore failed.
![image](https://user-images.githubusercontent.com/65671723/119241261-666d8580-bb55-11eb-998f-494239612076.png)

```
org.openqa.selenium.ElementClickInterceptedException: element click intercepted: Element <span class="select2-selection select2-selection--single" role="combobox" aria-haspopup="true" aria-expanded="false" tabindex="0" aria-disabled="false" aria-labelledby="select2-h87t-container">...</span> is not clickable at point (509, 379). Other element would receive the click: <p _ngcontent-nfa-c38="" class="pb-3 pb-md-0">...</p>
  (Session info: chrome=90.0.4430.212)
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
Driver info: org.openqa.selenium.chrome.ChromeDriver
Capabilities {acceptInsecureCerts: false, browserName: chrome, browserVersion: 90.0.4430.212, chrome: {chromedriverVersion: 90.0.4430.24 (4c6d850f087da..., userDataDir: C:\Users\Loris\AppData\Loca...}, goog:chromeOptions: {debuggerAddress: localhost:57379}, javascriptEnabled: true, networkConnectionEnabled: false, pageLoadStrategy: normal, platform: WINDOWS, platformName: WINDOWS, proxy: Proxy(), setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify, webauthn:extension:largeBlob: true, webauthn:virtualAuthenticators: true}
Session ID: 82eb50ec93fc4a183df965506c7bd74b
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.createException(W3CHttpResponseCodec.java:187)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:122)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:83)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
	at org.openqa.selenium.remote.RemoteWebElement.execute(RemoteWebElement.java:285)
	at org.openqa.selenium.remote.RemoteWebElement.click(RemoteWebElement.java:84)
	at de.tfr.impf.ReportJob.openMainPage(ReportJob.kt:209)
	at de.tfr.impf.ReportJob.checkLocation(ReportJob.kt:56)
	at de.tfr.impf.ReportJob.checkLocations(ReportJob.kt:44)
	at de.tfr.impf.ReportJob.reportFreeSlots(ReportJob.kt:37)
	at de.tfr.impf.StartKt.main(Start.kt:4)
	at de.tfr.impf.StartKt.main(Start.kt)

```

This accepts the cookies on that page as well and fixes that.